### PR TITLE
Fixed loaded dice

### DIFF
--- a/lib/Dice/die.ex
+++ b/lib/Dice/die.ex
@@ -7,10 +7,10 @@ defmodule Dice.Die do
   
   def roll(die), do: _side_at(die, _random_side_index(die))
 
-  defp _side_at(die, index), do: Enum.at(die, index - 1)
+  defp _side_at(die, index), do: Enum.at(die, index)
 
   defp _random_side_index(die), do: die |> num_sides |> _random
 
-  defp _random(n), do: :crypto.rand_uniform(0, n+1)
+  defp _random(n), do: :crypto.rand_uniform(0, n)
 
 end


### PR DESCRIPTION
This random number generator was used in a way that made it twice as likely to roll the highest number for any given die as any other number for that die.

The code `:crypto.rand_uniform(0, n+1)` increases the range of the uniform random number generator one higher than intended.  The range extends from `0` up to **and including** `num_sides`.

So, `Enum.at(die, index - 1)` would give the **highest** result if `index` was zero.  It would **also** give the highest result if `index` was `num_sides`.  This would make the highest result **twice** as likely as any other since all of the others are generated uniformly.

This would skew the mean of the dice rolls higher than the true mean, hence loading the dice.